### PR TITLE
Fix #62: Refactor cwSampleRate to pathSamplingRate for Enhanced Clarity

### DIFF
--- a/src/core/parameters.h
+++ b/src/core/parameters.h
@@ -25,29 +25,24 @@ namespace params
 		constexpr static RealType DEFAULT_C = 299792458.0; ///< Speed of light (m/s)
 		constexpr static RealType DEFAULT_BOLTZMANN_K = 1.3806503e-23; ///< Boltzmann constant
 		//constexpr static unsigned MIN_FILTER_LENGTH = 16; ///< Minimum render filter length
-
 		RealType c = DEFAULT_C; ///< Speed of light (modifiable)
 		RealType boltzmann_k = DEFAULT_BOLTZMANN_K; ///< Boltzmann constant (modifiable)
 		RealType start = 0; ///< Start time for the simulation.
 		RealType end = 0; ///< End time for the simulation.
-		RealType cw_sample_rate = 1000; ///< CW interpolation sample rate.
+		RealType path_sampling_rate = 1000; ///< The fidelity of the underlying physics simulation (Hz).
 		// Default to the location of the University of Cape Town in South Africa
 		double origin_latitude = -33.957652; ///< Geodetic origin latitude
 		double origin_longitude = 18.4611991; ///< Geodetic origin longitude
 		double origin_altitude = 111.01; ///< Geodetic origin altitude (in meters)
 		RealType rate = 0; ///< Rendering sample rate.
-
 		unsigned random_seed = 0; ///< Random seed for simulation.
 		unsigned adc_bits = 0; ///< ADC quantization bits.
 		unsigned filter_length = 33; ///< Default render filter length.
-
 		bool export_xml = false; ///< Enable or disable XML export.
 		bool export_csv = false; ///< Enable or disable CSV export.
 		bool export_binary = true; ///< Enable or disable binary export.
-
 		unsigned render_threads = 1; ///< Number of rendering threads to use.
 		unsigned oversample_ratio = 1; ///< Oversampling ratio.
-
 		std::optional<RealType> optional_rate = std::nullopt; ///< Optional sample rate.
 	};
 
@@ -78,10 +73,10 @@ namespace params
 	inline RealType endTime() noexcept { return params.end; }
 
 	/**
-	* @brief Get the CW interpolation sample rate.
-	* @return The CW sample rate.
+	* @brief Get the path sampling rate.
+	* @return The path sampling rate.
 	*/
-	inline RealType cwSampleRate() noexcept { return params.cw_sample_rate; }
+	inline RealType pathSamplingRate() noexcept { return params.path_sampling_rate; }
 
 	/**
 	* @brief Get the rendering sample rate.
@@ -160,13 +155,13 @@ namespace params
 	}
 
 	/**
-	* @brief Set the CW interpolation rate.
-	* @param rate The new CW sample rate.
+	* @brief Set the path sampling rate.
+	* @param rate The new path sampling rate.
 	*/
-	inline void setCwSampleRate(const RealType rate) noexcept
+	inline void setPathSamplingRate(const RealType rate) noexcept
 	{
-		params.cw_sample_rate = rate;
-		LOG(logging::Level::DEBUG, "CW interpolation rate set to: {:.5f} Hz", rate);
+		params.path_sampling_rate = rate;
+		LOG(logging::Level::DEBUG, "Path sampling rate set to: {:.5f} Hz", rate);
 	}
 
 	/**
@@ -238,11 +233,11 @@ namespace params
 	}
 
 	/**
-	 * @brief Set the geodetic origin for the KML generator.
-	 * @param lat The latitude of the origin.
-	 * @param lon The longitude of the origin.
-	 * @param alt The altitude of the origin (MSL).
-	 */
+	* @brief Set the geodetic origin for the KML generator.
+	* @param lat The latitude of the origin.
+	* @param lon The longitude of the origin.
+	* @param alt The altitude of the origin (MSL).
+	*/
 	inline void setOrigin(const double lat, const double lon, const double alt) noexcept
 	{
 		params.origin_latitude = lat;
@@ -252,7 +247,9 @@ namespace params
 	}
 
 	inline double originLatitude() noexcept { return params.origin_latitude; }
+
 	inline double originLongitude() noexcept { return params.origin_longitude; }
+
 	inline double originAltitude() noexcept { return params.origin_altitude; }
 
 	/**

--- a/src/core/sim_threading.cpp
+++ b/src/core/sim_threading.cpp
@@ -193,7 +193,7 @@ namespace
 
 	    const auto start_time = std::chrono::duration<RealType>(signal->time);
 	    const auto end_time = start_time + std::chrono::duration<RealType>(signal->wave->getLength());
-	    const auto sample_time = std::chrono::duration<RealType>(1.0 / params::cwSampleRate());
+	    const auto sample_time = std::chrono::duration<RealType>(1.0 / params::pathSamplingRate());
 	    const int point_count = static_cast<int>(std::ceil(signal->wave->getLength() / sample_time.count()));
 
 	    // Check for a valid point count in case of target simulation

--- a/src/serial/xml_parser.cpp
+++ b/src/serial/xml_parser.cpp
@@ -138,7 +138,7 @@ namespace
 		};
 
 		set_param_with_exception_handling(parameters, "c", params::c(), params::setC);
-		set_param_with_exception_handling(parameters, "interprate", params::cwSampleRate(), params::setCwSampleRate);
+		set_param_with_exception_handling(parameters, "pathSamplingRate", params::pathSamplingRate(), params::setPathSamplingRate);
 
 		set_param_with_exception_handling(parameters, "randomseed", params::randomSeed(), params::setRandomSeed);
 		set_param_with_exception_handling(parameters, "adc_bits", params::adcBits(), params::setAdcBits);

--- a/test/sim_tests/test1/input.fersxml
+++ b/test/sim_tests/test1/input.fersxml
@@ -7,7 +7,7 @@
         <endtime>1.0</endtime>
         <rate>1e6</rate>
         <c>299792458.0</c>
-        <interprate>1e6</interprate>
+        <pathSamplingRate>1e6</pathSamplingRate>
         <randomseed>12345</randomseed>
         <export csv="true" binary="true" xml="true"/>
     </parameters>

--- a/test/sim_tests/test6/input.fersxml
+++ b/test/sim_tests/test6/input.fersxml
@@ -7,7 +7,7 @@
         <endtime>10</endtime>
         <rate>1e8</rate>
         <c>299792458</c>
-        <interprate>1000</interprate>
+        <pathSamplingRate>1000</pathSamplingRate>
         <randomseed>4444</randomseed>
         <adc_bits>12</adc_bits>
         <oversample>2</oversample>

--- a/xml_schema/fers-xml.dtd
+++ b/xml_schema/fers-xml.dtd
@@ -3,15 +3,15 @@
         <!ATTLIST simulation name CDATA #REQUIRED>
 
         <!-- Simulation Parameters -->
-        <!ELEMENT parameters (starttime,endtime,rate,c?,interprate?,randomseed?,adc_bits?,oversample?,origin?,export?)>
+        <!ELEMENT parameters (starttime,endtime,rate,c?,pathSamplingRate?,randomseed?,adc_bits?,oversample?,origin?,export?)>
         <!-- Start time of simulation -->
         <!ELEMENT starttime (#PCDATA)>
         <!-- End time of simulation -->
         <!ELEMENT endtime (#PCDATA)>
         <!-- Propagation speed -->
         <!ELEMENT c (#PCDATA)>
-        <!-- Position interpolation rate for CW -->
-        <!ELEMENT interprate (#PCDATA)>
+        <!-- Fidelity of the underlying physics simulation (Hz) -->
+        <!ELEMENT pathSamplingRate (#PCDATA)>
         <!-- Override the rendering sample rate with the specified one (Hz) -->
         <!ELEMENT rate (#PCDATA)>
         <!-- Random seed for noise -->

--- a/xml_schema/fers-xml.xsd
+++ b/xml_schema/fers-xml.xsd
@@ -38,7 +38,7 @@
                 <xs:element name="endtime" type="xs:string"/>
                 <xs:element name="rate" type="xs:string"/>
                 <xs:element minOccurs="0" name="c" type="xs:string"/>
-                <xs:element minOccurs="0" name="interprate" type="xs:string"/>
+                <xs:element minOccurs="0" name="pathSamplingRate" type="xs:string"/>
                 <xs:element minOccurs="0" name="randomseed" type="xs:string"/>
                 <xs:element minOccurs="0" name="adc_bits" type="xs:string"/>
                 <xs:element minOccurs="0" name="oversample" type="xs:string"/>


### PR DESCRIPTION
Closes #62

---

### Summary

This pull request refactors a critical global simulation parameter, previously named `cwSampleRate` (and its XML alias `<interprate>`), to the more descriptive and accurate `pathSamplingRate`. This change significantly improves the clarity and maintainability of the codebase, especially as native Continuous Wave (CW) mode features are introduced.

### Motivation & Problem Solved

The parameter `params::cwSampleRate()` was originally intended to define the time-step resolution for the underlying physics simulation, regardless of whether the simulation was in pulsed or CW mode. It governed how frequently the simulator sampled platform motion and rotation paths to calculate instantaneous physical interactions (range, velocity, antenna gain, etc.).

The previous naming presented several significant issues:

1.  **Ambiguity and Confusion:** The name `cwSampleRate` was highly misleading. It incorrectly implied exclusive use for CW mode, despite being a fundamental parameter for pulsed simulations as well.
2.  **Naming Conflict (Future):** With the upcoming implementation of native CW support, a *true* CW sampling rate (representing the receiver's ADC) will be introduced. The existing `cwSampleRate` would directly conflict with this new, distinct concept, leading to severe confusion and potential bugs.
3.  **Unintuitive Configuration:** The XML tag `<interprate>` was vague and failed to clearly communicate its purpose to end-users. It was not immediately obvious that this parameter controlled the fidelity of the dynamics simulation.

This refactoring directly addresses these problems by providing a name that accurately reflects the parameter's function, avoids future naming collisions, and makes the simulator's configuration more intuitive.

### Proposed Solution & Key Changes

The solution involved a clean, comprehensive refactoring of this parameter across the entire codebase and configuration schema. The changes include:

1.  **Core Parameter Rename:**
    *   In `src/core/parameters.h`, the member `Parameters::cw_sample_rate` has been renamed to `Parameters::path_sampling_rate`.
    *   The corresponding accessor functions `cwSampleRate()` and `setCwSampleRate()` were renamed to `pathSamplingRate()` and `setPathSamplingRate()`, respectively, along with their Doxygen comments.

2.  **XML Schema Update:**
    *   In `xml_schema/fers-xml.xsd` and `xml_schema/fers-xml.dtd`, the `<interprate>` element has been renamed to `<pathSamplingRate>`.

3.  **XML Parser Update:**
    *   In `src/serial/xml_parser.cpp`, the parsing logic was modified to correctly identify the new `<pathSamplingRate>` tag and invoke the new `setPathSamplingRate()` function.

4.  **Global Usage Refactor:**
    *   All instances of `params::cwSampleRate()` across the project, including critical areas like `src/core/sim_threading.cpp` where the physics time-step is calculated, have been updated to use `params::pathSamplingRate()`.
    *   Example XML input files in `test/sim_tests/` (`test1/input.fersxml`, `test6/input.fersxml`) were also updated to reflect the new XML tag.

This change establishes a clear distinction between the three key rate parameters in the simulator:
*   **`pathSamplingRate`**: The fidelity of the underlying physics simulation (applies to all modes).
*   **`rate`**: The final output sample rate for rendered *pulsed* signals.
*   **`cwProcessing::samplingRate`**: (Future, but concept is key) The physical ADC sample rate for the baseband I/Q signal in *CW mode*.

### Alternatives Considered

*   **`sceneSamplingRate` or `dynamicsUpdateRate`**: These were considered as alternative names. However, `pathSamplingRate` was chosen for its directness in describing what is being sampled: the `motionpath` and `rotationpath` of the platforms.
*   **Leaving the names as is**: This was deemed not viable due to the significant confusion and potential for bugs it would introduce as native CW features are fully implemented.

### How to Test

As this is a purely refactoring change, the primary method for verification is ensuring that existing functionality remains unchanged.

1.  **Build FERS:** Ensure the project compiles successfully after the changes.
2.  **Run Regression Tests:** All existing regression tests in `test/sim_tests/` should pass without issue. This confirms that the refactoring has not altered the simulation's outputs or behavior.
    ```bash
    cd FERS
    python3 -m venv venv
    source venv/bin/activate
    pip install -r requirements.txt
    python3 run_sim_tests.py
    ```
    The regression tests will confirm that simulations run with the new `<pathSamplingRate>` XML tag produce identical outputs to those run with the old `<interprate>` tag.