### PR TITLE
 Build: Fix Compilation Issues and Add Build Steps for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,15 @@
 cmake_minimum_required(VERSION 3.13)
 project(fers)
 
+if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	# On macOS, when using a Homebrew LLVM toolchain for modern C++ features,
+	# we must explicitly tell the linker where to find the corresponding
+	# Homebrew libc++ library. Otherwise, it defaults to the older,
+	# incompatible system version.
+	message(STATUS "macOS with Clang detected. Setting linker paths for Homebrew libc++.")
+	link_directories(/usr/local/opt/llvm/lib/c++)
+endif()
+
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)  # Useful for static code analysis tools
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,45 @@ sudo ldconfig
 
 You can use **CMake GUI** for manual configuration by navigating to the HDF5 paths as needed.
 
+### Building on macOS (Intel/Homebrew)
+
+FERS uses modern C++20/23 features, which require a modern compiler toolchain. The default Clang provided by macOS may link against an older, incompatible version of the C++ standard library. Therefore, it is necessary to install and use the LLVM toolchain provided by Homebrew.
+
+**1. Install Dependencies**
+
+First, install the required libraries and build tools using Homebrew:
+
+```bash
+brew install cmake hdf5 libxml2
+```
+
+**2. Install Modern LLVM Toolchain**
+
+Next, install the latest LLVM compiler suite from Homebrew:
+
+```bash
+brew install llvm
+```
+
+**3. Configure and Build**
+
+To ensure CMake uses the correct Homebrew-installed Clang compiler, you must set the `CC` and `CXX` environment variables before running the configuration step.
+
+Follow these steps from the root of the project directory:
+
+```bash
+# Create and navigate to the build directory
+mkdir build && cd build
+
+# Configure the project using the Homebrew Clang compiler
+CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ cmake ..
+
+# Compile the project
+make -j$(sysctl -n hw.ncpu)
+```
+
+After the build completes, the `fers` executable will be located in the `build/src` directory.
+
 ## Regression Testing Suite
 
 The FERS modernization includes a comprehensive **regression testing suite**

--- a/src/config.h
+++ b/src/config.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <complex>
+#include <numbers>
 
 /**
 * @brief Type for real numbers.

--- a/src/core/logging.cpp
+++ b/src/core/logging.cpp
@@ -13,7 +13,7 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
-#include <bits/chrono.h>
+#include <chrono>
 
 namespace logging
 {

--- a/src/core/portable_utils.h
+++ b/src/core/portable_utils.h
@@ -21,7 +21,7 @@ namespace core
 	 * @param x The value for which the Bessel function is to be computed.
 	 * @return The computed value of the Bessel function of the first kind (order 1).
 	 */
-	inline RealType besselJ1(const RealType x) noexcept { return std::cyl_bessel_j(1, x); }
+	inline RealType besselJ1(const RealType x) noexcept { return j1(x); }
 
 	/**
 	 * @brief Detects the number of CPUs on the machine.

--- a/src/core/sim_threading.cpp
+++ b/src/core/sim_threading.cpp
@@ -16,7 +16,7 @@
 #include <thread>
 #include <utility>
 #include <vector>
-#include <bits/chrono.h>
+#include <chrono>
 
 #include "parameters.h"
 #include "thread_pool.h"
@@ -33,7 +33,7 @@ using radar::Transmitter;
 using radar::Receiver;
 using radar::Target;
 using math::SVec3;
-using signal::RadarSignal;
+using fers_signal::RadarSignal;
 using radar::TransmitterPulse;
 using serial::Response;
 using logging::Level;

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -13,7 +13,7 @@
 #include "signal/radar_signal.h"
 #include "timing/prototype_timing.h"
 
-using signal::RadarSignal;
+using fers_signal::RadarSignal;
 using antenna::Antenna;
 using timing::PrototypeTiming;
 using radar::Platform;

--- a/src/core/world.h
+++ b/src/core/world.h
@@ -76,7 +76,7 @@ namespace core
 		* @param pulse A unique pointer to a RadarSignal object.
 		* @throws std::runtime_error if a pulse with the same name already exists.
 		*/
-		void add(std::unique_ptr<signal::RadarSignal> pulse);
+		void add(std::unique_ptr<fers_signal::RadarSignal> pulse);
 
 		/**
 		* @brief Adds an antenna to the simulation world.
@@ -100,7 +100,7 @@ namespace core
 		* @param name The name of the radar signal to find.
 		* @return A pointer to the RadarSignal if found, or nullptr if not found.
 		*/
-		[[nodiscard]] signal::RadarSignal* findSignal(const std::string& name);
+		[[nodiscard]] fers_signal::RadarSignal* findSignal(const std::string& name);
 
 		/**
 		* @brief Finds an antenna by name.
@@ -157,7 +157,7 @@ namespace core
 
 		std::vector<std::unique_ptr<radar::Target>> _targets;
 
-		std::unordered_map<std::string, std::unique_ptr<signal::RadarSignal>> _pulses;
+		std::unordered_map<std::string, std::unique_ptr<fers_signal::RadarSignal>> _pulses;
 
 		std::unordered_map<std::string, std::unique_ptr<antenna::Antenna>> _antennas;
 

--- a/src/interpolation/interpolation_set.cpp
+++ b/src/interpolation/interpolation_set.cpp
@@ -14,7 +14,7 @@
 #include <ranges>
 #include <stdexcept>
 #include <utility>
-#include <bits/std_abs.h>
+#include <cmath>
 
 namespace interp
 {

--- a/src/noise/falpha_branch.cpp
+++ b/src/noise/falpha_branch.cpp
@@ -18,8 +18,8 @@
 #include "signal/dsp_filters.h"
 
 using logging::Level;
-using signal::IirFilter;
-using signal::DecadeUpsampler;
+using fers_signal::IirFilter;
+using fers_signal::DecadeUpsampler;
 
 namespace noise
 {

--- a/src/noise/falpha_branch.h
+++ b/src/noise/falpha_branch.h
@@ -85,13 +85,13 @@ namespace noise
 
 		std::normal_distribution<RealType> _normal_dist; ///< Normal distribution for generating white Gaussian noise.
 
-		std::unique_ptr<signal::IirFilter> _shape_filter; ///< Filter used for shaping the noise signal.
+		std::unique_ptr<fers_signal::IirFilter> _shape_filter; ///< Filter used for shaping the noise signal.
 
-		std::unique_ptr<signal::IirFilter> _integ_filter; ///< Filter used for integrating the noise signal.
+		std::unique_ptr<fers_signal::IirFilter> _integ_filter; ///< Filter used for integrating the noise signal.
 
-		std::unique_ptr<signal::IirFilter> _highpass; ///< High-pass filter to remove low-frequency components.
+		std::unique_ptr<fers_signal::IirFilter> _highpass; ///< High-pass filter to remove low-frequency components.
 
-		std::unique_ptr<signal::DecadeUpsampler> _upsampler; ///< Upsampler for generating higher-frequency components.
+		std::unique_ptr<fers_signal::DecadeUpsampler> _upsampler; ///< Upsampler for generating higher-frequency components.
 
 		std::unique_ptr<FAlphaBranch> _pre; ///< Previous FAlphaBranch in the chain for recursive noise processing.
 

--- a/src/radar/receiver.h
+++ b/src/radar/receiver.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <random>
+#include <mutex>
 
 #include "radar_obj.h"
 #include "serial/response.h"

--- a/src/radar/transmitter.h
+++ b/src/radar/transmitter.h
@@ -10,7 +10,7 @@
 
 #include "radar_obj.h"
 
-namespace signal
+namespace fers_signal
 {
 	class RadarSignal;
 }
@@ -24,7 +24,7 @@ namespace radar
 	*/
 	struct TransmitterPulse
 	{
-		signal::RadarSignal* wave; ///< Pointer to the radar signal wave.
+		fers_signal::RadarSignal* wave; ///< Pointer to the radar signal wave.
 
 		RealType time; ///< Time at which the pulse is emitted.
 	};
@@ -68,7 +68,7 @@ namespace radar
 		*
 		* @return Pointer to the RadarSignal object being transmitted.
 		*/
-		[[nodiscard]] signal::RadarSignal* getSignal() const noexcept { return _signal; }
+		[[nodiscard]] fers_signal::RadarSignal* getSignal() const noexcept { return _signal; }
 
 		/**
 		* @brief Checks if the transmitter is pulsed.
@@ -89,14 +89,14 @@ namespace radar
 		*
 		* @param pulse Pointer to the RadarSignal object representing the wave.
 		*/
-		void setWave(signal::RadarSignal* pulse) noexcept { _signal = pulse; }
+		void setWave(fers_signal::RadarSignal* pulse) noexcept { _signal = pulse; }
 
 		/**
 		* @brief Sets the radar signal wave to be transmitted.
 		*
 		* @param signal Pointer to the RadarSignal object to be transmitted.
 		*/
-		void setSignal(signal::RadarSignal* signal) noexcept { _signal = signal; }
+		void setSignal(fers_signal::RadarSignal* signal) noexcept { _signal = signal; }
 
 		/**
 		* @brief Sets whether the transmitter is pulsed or continuous wave.
@@ -122,7 +122,7 @@ namespace radar
 		void setPrf(RealType mprf) noexcept;
 
 	private:
-		signal::RadarSignal* _signal = nullptr; ///< Pointer to the radar signal being transmitted.
+		fers_signal::RadarSignal* _signal = nullptr; ///< Pointer to the radar signal being transmitted.
 
 		RealType _prf = {}; ///< The pulse repetition frequency (PRF) of the transmitter.
 

--- a/src/serial/pulse_factory.cpp
+++ b/src/serial/pulse_factory.cpp
@@ -23,8 +23,8 @@
 #include "core/parameters.h"
 #include "signal/radar_signal.h"
 
-using signal::Signal;
-using signal::RadarSignal;
+using fers_signal::Signal;
+using fers_signal::RadarSignal;
 
 namespace
 {

--- a/src/serial/pulse_factory.h
+++ b/src/serial/pulse_factory.h
@@ -13,7 +13,7 @@
 
 #include "config.h"
 
-namespace signal
+namespace fers_signal
 {
 	class RadarSignal;
 }
@@ -30,6 +30,6 @@ namespace serial
 	* @return A unique pointer to a RadarSignal object loaded with the pulse data.
 	* @throws std::runtime_error If the file cannot be opened or the file format is unrecognized.
 	*/
-	[[nodiscard]] std::unique_ptr<signal::RadarSignal> loadPulseFromFile(
+	[[nodiscard]] std::unique_ptr<fers_signal::RadarSignal> loadPulseFromFile(
 		const std::string& name, const std::string& filename, RealType power, RealType carrierFreq);
 }

--- a/src/serial/receiver_export.cpp
+++ b/src/serial/receiver_export.cpp
@@ -448,7 +448,7 @@ namespace serial
 
 			renderWindow(window, length, start, frac_delay, responses, pool);
 
-			if (params::oversampleRatio() > 1) { window = std::move(signal::downsample(window)); }
+			if (params::oversampleRatio() > 1) { window = std::move(fers_signal::downsample(window)); }
 
 			if (pn_enabled) { addPhaseNoiseToWindow(pnoise, window); }
 

--- a/src/serial/response.h
+++ b/src/serial/response.h
@@ -17,7 +17,7 @@
 
 class XmlElement;
 
-namespace signal
+namespace fers_signal
 {
 	class RadarSignal;
 }
@@ -42,7 +42,7 @@ namespace serial
 		* @param wave Pointer to the radar signal object.
 		* @param transmitter Pointer to the transmitter object.
 		*/
-		Response(const signal::RadarSignal* wave, const radar::Transmitter* transmitter) noexcept :
+		Response(const fers_signal::RadarSignal* wave, const radar::Transmitter* transmitter) noexcept :
 			_transmitter(transmitter), _wave(wave) {}
 
 		~Response() = default;
@@ -113,7 +113,7 @@ namespace serial
 
 	private:
 		const radar::Transmitter* _transmitter; ///< Pointer to the transmitter object.
-		const signal::RadarSignal* _wave; ///< Pointer to the radar signal object.
+		const fers_signal::RadarSignal* _wave; ///< Pointer to the radar signal object.
 		std::vector<interp::InterpPoint> _points; ///< Vector of interpolation points.
 
 		/**

--- a/src/serial/xml_parser.cpp
+++ b/src/serial/xml_parser.cpp
@@ -46,7 +46,7 @@ using radar::Platform;
 using math::Path;
 using math::RotationPath;
 using radar::Target;
-using signal::RadarSignal;
+using fers_signal::RadarSignal;
 using timing::Timing;
 using timing::PrototypeTiming;
 using radar::Transmitter;

--- a/src/signal/dsp_filters.cpp
+++ b/src/signal/dsp_filters.cpp
@@ -60,7 +60,7 @@ namespace
 	}
 }
 
-namespace signal
+namespace fers_signal
 {
 	void upsample(const std::span<const ComplexType> in, const unsigned size, std::span<ComplexType> out)
 	{

--- a/src/signal/dsp_filters.h
+++ b/src/signal/dsp_filters.h
@@ -14,7 +14,7 @@
 
 #include "config.h"
 
-namespace signal
+namespace fers_signal
 {
 	/**
 	* @brief Upsamples a signal by a given ratio.

--- a/src/signal/radar_signal.cpp
+++ b/src/signal/radar_signal.cpp
@@ -20,7 +20,7 @@
 #include "interpolation/interpolation_filter.h"
 #include "interpolation/interpolation_point.h"
 
-namespace signal
+namespace fers_signal
 {
 
 	RadarSignal::RadarSignal(std::string name, const RealType power, const RealType carrierfreq, const RealType length,

--- a/src/signal/radar_signal.h
+++ b/src/signal/radar_signal.h
@@ -21,7 +21,7 @@ namespace interp
 	struct InterpPoint;
 }
 
-namespace signal
+namespace fers_signal
 {
 	/**
 	 * @class Signal


### PR DESCRIPTION
### **Description**

This pull request resolves a series of compilation and linking errors encountered when building the FERS project on an Intel-based macOS machine using the Homebrew LLVM/Clang toolchain. The primary issue was related to the linker defaulting to the system's outdated `libc++`, which is incompatible with the C++20/23 features used in the codebase.

This branch addresses the root linker issue, includes several portability fixes exposed by the stricter Clang compiler, and **updates the project documentation with detailed build instructions for macOS.**

### **Changes Overview**

#### 1. CMake Linker Configuration for macOS
The core fix is in the root `CMakeLists.txt`. A new block has been added to detect when compiling on macOS (`APPLE`) with Clang. If detected, it explicitly adds the Homebrew LLVM `libc++` directory (`/usr/local/opt/llvm/lib/c++`) to the linker search path.

```cmake
if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
	# ... (comment explaining the why)
	link_directories(/usr/local/opt/llvm/lib/c++)
endif()
```
This ensures that the project links against the correct, modern C++ standard library provided by Homebrew, resolving symbol mismatch errors.

#### 2. Namespace Refactoring: `signal` -> `fers_signal`
The `signal` namespace has been renamed to `fers_signal` throughout the codebase. The original name is highly generic and prone to conflicts with the standard C `<signal.h>` header, which can cause ambiguous symbol errors on POSIX-compliant systems like macOS. This change makes the codebase more robust and portable.

#### 3. Portability and Header Fixes
Several non-portable header includes and function calls were replaced with their standard, cross-platform equivalents to satisfy stricter compiler requirements:
- **Standard Headers**: Replaced non-standard GNU headers (`<bits/chrono.h>`, etc.) with standard `<chrono>`, `<cmath>`.
- **Bessel Function**: Switched from `std::cyl_bessel_j` to `j1()` for broader toolchain compatibility.
- **Added Includes**: Added necessary headers like `<numbers>` and `<mutex>` to ensure dependencies are explicitly declared.

### **Documentation Update**

The `README.md` has been updated with a new section detailing the step-by-step process for compiling the project on macOS with Homebrew, including environment variable setup to correctly point CMake to the modern LLVM toolchain.

### **Motivation**

While developing on Linux/GCC, the project compiled without issues. However, attempting to build on macOS/Clang revealed latent portability problems. This PR broadens platform support and provides clear documentation to ensure FERS can be built successfully in different environments, making the project more accessible and maintainable.