### PR TITLE
feat(ui): Add 3D Viewport Camera Controls

### DIFF
--- a/packages/fers-ui/package.json
+++ b/packages/fers-ui/package.json
@@ -36,6 +36,7 @@
         "react-dom": "^19.2.0",
         "react-resizable-panels": "^3.0.0",
         "three": "^0.180.0",
+        "three-stdlib": "^2.36.0",
         "uuid": "^13.0.0",
         "zod": "^4.1.12",
         "zustand": "^5.0.8"

--- a/packages/fers-ui/pnpm-lock.yaml
+++ b/packages/fers-ui/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       three:
         specifier: ^0.180.0
         version: 0.180.0
+      three-stdlib:
+        specifier: ^2.36.0
+        version: 2.36.0(three@0.180.0)
       uuid:
         specifier: ^13.0.0
         version: 13.0.0

--- a/packages/fers-ui/src/components/CameraManager.tsx
+++ b/packages/fers-ui/src/components/CameraManager.tsx
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2025-present FERS Contributors (see AUTHORS.md).
+
+import { useEffect, useRef } from 'react';
+import { useThree, useFrame } from '@react-three/fiber';
+import {
+    useScenarioStore,
+    calculateInterpolatedPosition,
+} from '@/stores/scenarioStore';
+import { type MapControls as MapControlsImpl } from 'three-stdlib';
+import * as THREE from 'three';
+
+interface CameraManagerProps {
+    controlsRef: React.RefObject<MapControlsImpl | null>;
+}
+
+export default function CameraManager({ controlsRef }: CameraManagerProps) {
+    const { camera } = useThree();
+
+    const platforms = useScenarioStore((state) => state.platforms);
+    const viewControlAction = useScenarioStore(
+        (state) => state.viewControlAction
+    );
+    const clearViewControlAction = useScenarioStore(
+        (state) => state.clearViewControlAction
+    );
+
+    const lastActionTimestamp = useRef(0);
+
+    useEffect(() => {
+        if (
+            !controlsRef.current ||
+            viewControlAction.timestamp === lastActionTimestamp.current
+        ) {
+            return;
+        }
+
+        const controls = controlsRef.current;
+        const { type, targetId } = viewControlAction;
+
+        if (type === 'frame') {
+            const box = new THREE.Box3();
+            let hasPoints = false;
+
+            platforms.forEach((platform) => {
+                (platform.pathPoints ?? []).forEach((point: THREE.Vector3) => {
+                    box.expandByPoint(point);
+                    hasPoints = true;
+                });
+            });
+
+            if (
+                hasPoints &&
+                !box.isEmpty() &&
+                camera instanceof THREE.PerspectiveCamera
+            ) {
+                const center = new THREE.Vector3();
+                box.getCenter(center);
+                const size = new THREE.Vector3();
+                box.getSize(size);
+
+                const maxDim = Math.max(size.x, size.y, size.z);
+                const fov = camera.fov * (Math.PI / 180);
+                let cameraZ = Math.abs(maxDim / 2 / Math.tan(fov / 2));
+                cameraZ *= 1.5;
+
+                const newPos = new THREE.Vector3(
+                    center.x,
+                    center.y + cameraZ / 2,
+                    center.z + cameraZ
+                );
+
+                camera.position.copy(newPos);
+                controls.target.copy(center);
+                controls.update();
+            }
+
+            lastActionTimestamp.current = viewControlAction.timestamp;
+            clearViewControlAction();
+        } else if (type === 'focus' && targetId) {
+            const platform = platforms.find((p) => p.id === targetId);
+            if (platform) {
+                const currentTime = useScenarioStore.getState().currentTime;
+                const position = calculateInterpolatedPosition(
+                    platform,
+                    currentTime
+                );
+                controls.target.copy(position);
+                controls.update();
+            }
+            lastActionTimestamp.current = viewControlAction.timestamp;
+            clearViewControlAction();
+        }
+    }, [
+        viewControlAction,
+        controlsRef,
+        camera,
+        platforms,
+        clearViewControlAction,
+    ]);
+    useFrame(() => {
+        if (
+            !controlsRef.current ||
+            viewControlAction.type !== 'follow' ||
+            !viewControlAction.targetId
+        ) {
+            return;
+        }
+
+        const controls = controlsRef.current;
+        const platform = platforms.find(
+            (p) => p.id === viewControlAction.targetId
+        );
+
+        if (platform) {
+            const position = calculateInterpolatedPosition(
+                platform,
+                useScenarioStore.getState().currentTime
+            );
+            controls.target.copy(position);
+            controls.update();
+        }
+    });
+
+    return null;
+}

--- a/packages/fers-ui/src/components/ViewControls.tsx
+++ b/packages/fers-ui/src/components/ViewControls.tsx
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2025-present FERS Contributors (see AUTHORS.md).
+
+import { Box, IconButton, Tooltip } from '@mui/material';
+import CenterFocusStrongIcon from '@mui/icons-material/CenterFocusStrong';
+import TravelExploreIcon from '@mui/icons-material/TravelExplore';
+import VideocamIcon from '@mui/icons-material/Videocam';
+import VideocamOffIcon from '@mui/icons-material/VideocamOff';
+import { useScenarioStore } from '@/stores/scenarioStore';
+
+export default function ViewControls() {
+    const {
+        frameScene,
+        focusOnItem,
+        toggleFollowItem,
+        selectedItemId,
+        viewControlAction,
+    } = useScenarioStore();
+    const isFollowing =
+        viewControlAction.type === 'follow' &&
+        viewControlAction.targetId === selectedItemId;
+
+    return (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <Tooltip title="Frame Scene" placement="right">
+                <IconButton
+                    onClick={frameScene}
+                    color="primary"
+                    sx={{ bgcolor: 'background.paper' }}
+                >
+                    <TravelExploreIcon />
+                </IconButton>
+            </Tooltip>
+            <Tooltip title="Focus on Selected" placement="right">
+                <span>
+                    <IconButton
+                        onClick={() =>
+                            selectedItemId && focusOnItem(selectedItemId)
+                        }
+                        disabled={!selectedItemId}
+                        color="primary"
+                        sx={{ bgcolor: 'background.paper' }}
+                    >
+                        <CenterFocusStrongIcon />
+                    </IconButton>
+                </span>
+            </Tooltip>
+            <Tooltip
+                title={isFollowing ? 'Unfollow Selected' : 'Follow Selected'}
+                placement="right"
+            >
+                <span>
+                    <IconButton
+                        onClick={() =>
+                            selectedItemId && toggleFollowItem(selectedItemId)
+                        }
+                        disabled={!selectedItemId}
+                        color={isFollowing ? 'secondary' : 'primary'}
+                        sx={{ bgcolor: 'background.paper' }}
+                    >
+                        {isFollowing ? <VideocamOffIcon /> : <VideocamIcon />}
+                    </IconButton>
+                </span>
+            </Tooltip>
+        </Box>
+    );
+}

--- a/packages/fers-ui/src/stores/scenarioStore/index.ts
+++ b/packages/fers-ui/src/stores/scenarioStore/index.ts
@@ -30,6 +30,7 @@ export const useScenarioStore = create<ScenarioStore>()(
             open: false,
             message: '',
         },
+        viewControlAction: { type: null, timestamp: 0 },
 
         // Slices
         ...createAssetSlice(set, get, store),
@@ -54,6 +55,51 @@ export const useScenarioStore = create<ScenarioStore>()(
                     duration !== null && duration > 0 ? duration : null,
             }),
         setIsSimulating: (isSimulating) => set({ isSimulating }),
+
+        frameScene: () =>
+            set({
+                viewControlAction: { type: 'frame', timestamp: Date.now() },
+            }),
+        focusOnItem: (itemId) =>
+            set({
+                viewControlAction: {
+                    type: 'focus',
+                    targetId: itemId,
+                    timestamp: Date.now(),
+                },
+            }),
+        toggleFollowItem: (itemId) => {
+            const currentAction = get().viewControlAction;
+            if (
+                currentAction.type === 'follow' &&
+                currentAction.targetId === itemId
+            ) {
+                set({
+                    viewControlAction: { type: null, timestamp: Date.now() },
+                });
+            } else {
+                set({
+                    viewControlAction: {
+                        type: 'follow',
+                        targetId: itemId,
+                        timestamp: Date.now(),
+                    },
+                });
+            }
+        },
+        clearViewControlAction: () =>
+            set((state) => {
+                // Don't clear a 'follow' action, as it's persistent until toggled off.
+                if (state.viewControlAction.type !== 'follow') {
+                    return {
+                        viewControlAction: {
+                            type: null,
+                            timestamp: state.viewControlAction.timestamp,
+                        },
+                    };
+                }
+                return {};
+            }),
 
         // Error Actions
         showError: (message) => set({ errorSnackbar: { open: true, message } }),

--- a/packages/fers-ui/src/stores/scenarioStore/utils.ts
+++ b/packages/fers-ui/src/stores/scenarioStore/utils.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-only
 // Copyright (c) 2025-present FERS Contributors (see AUTHORS.md).
 
-import { ScenarioState, ScenarioItem } from './types';
+import { ScenarioState, ScenarioItem, Platform } from './types';
+import { Vector3 } from 'three';
 
 // Helper to set nested properties safely
 export const setPropertyByPath = (
@@ -47,3 +48,58 @@ export const findItemInStore = (
     }
     return null;
 };
+
+/**
+ * Calculates a platform's interpolated 3D position at a specific time.
+ * This function relies on the pre-fetched `pathPoints` array stored on the platform object.
+ * @param {Platform} platform The platform data, including its waypoints and cached path points.
+ * @param {number} currentTime The global simulation time.
+ * @returns {Vector3} The interpolated position in Three.js coordinates.
+ */
+export function calculateInterpolatedPosition(
+    platform: Platform,
+    currentTime: number
+): Vector3 {
+    const { waypoints, interpolation } = platform.motionPath;
+    const pathPoints = platform.pathPoints ?? [];
+
+    const firstWaypoint = waypoints[0];
+    if (!firstWaypoint) return new Vector3(0, 0, 0);
+
+    const staticPosition = new Vector3(
+        firstWaypoint.x ?? 0,
+        firstWaypoint.altitude ?? 0,
+        -(firstWaypoint.y ?? 0)
+    );
+
+    if (
+        interpolation === 'static' ||
+        waypoints.length < 2 ||
+        pathPoints.length < 2
+    ) {
+        return staticPosition;
+    }
+
+    const lastWaypoint = waypoints[waypoints.length - 1];
+    const pathStartTime = firstWaypoint.time;
+    const pathEndTime = lastWaypoint.time;
+    const pathDuration = pathEndTime - pathStartTime;
+
+    if (pathDuration <= 0) return staticPosition;
+
+    const timeRatio = (currentTime - pathStartTime) / pathDuration;
+    const clampedRatio = Math.max(0, Math.min(1, timeRatio));
+
+    const floatIndex = clampedRatio * (pathPoints.length - 1);
+    const index1 = Math.floor(floatIndex);
+    const index2 = Math.min(pathPoints.length - 1, Math.ceil(floatIndex));
+
+    const point1 = pathPoints[index1];
+    const point2 = pathPoints[index2];
+
+    if (!point1 || !point2) return staticPosition;
+    if (index1 === index2) return point1.clone();
+
+    const interPointRatio = floatIndex - index1;
+    return point1.clone().lerp(point2, interPointRatio);
+}

--- a/packages/fers-ui/src/views/ScenarioView.tsx
+++ b/packages/fers-ui/src/views/ScenarioView.tsx
@@ -15,6 +15,7 @@ import WorldView from '@/components/WorldView';
 import SceneTree from '@/components/SceneTree';
 import PropertyInspector from '@/components/PropertyInspector';
 import Timeline from '@/components/Timeline';
+import ViewControls from '@/components/ViewControls';
 import { useScenarioStore } from '@/stores/scenarioStore';
 
 /**
@@ -105,6 +106,16 @@ export const ScenarioView = React.memo(function ScenarioView() {
                             >
                                 <WorldView />
                             </Canvas>
+                            <Box
+                                sx={{
+                                    position: 'absolute',
+                                    top: 16,
+                                    left: 16,
+                                    zIndex: 1,
+                                }}
+                            >
+                                <ViewControls />
+                            </Box>
                         </Box>
                         <Box
                             sx={{


### PR DESCRIPTION
This pull request adds camera controls to the 3D viewport and refactors the management of platform motion path data. A new UI panel provides controls for framing the entire scene, focusing on a selected object, and following a selected object.

To support this, the logic for fetching and interpolating motion paths has been moved from the `WorldView` component into the Zustand store. Path data is now fetched once per platform and cached in the global state, where it is used by both the rendering components and the new camera control system.

### Changes

**1. New Functionality**

*   **Frame Scene:** Adjusts the camera to view all platform motion paths.
*   **Focus on Selected:** Sets the camera target to the selected platform's current position.
*   **Follow Selected:** A toggleable mode that continuously updates the camera target to the selected platform's position, effective during timeline playback.

**2. New Components**

*   **`ViewControls.tsx`:** A UI component that provides buttons for the "Frame," "Focus," and "Follow" actions. It is positioned in the top-left of the 3D viewport.
*   **`CameraManager.tsx`:** A component within the `react-three-fiber` canvas that listens for state changes and updates the camera and `MapControls` accordingly.

**3. State Management & Data Flow Refactoring**

*   **Zustand Store (`scenarioStore`)**:
    *   A `viewControlAction` object has been added to the state to communicate camera commands from the UI to the `CameraManager`.
    *   A `fetchPlatformPath` action was added to `platformSlice`. This action calls the Tauri backend to get interpolated motion path points.
    *   The fetched path data (`Vector3[]`) is now stored as an optional `pathPoints` property on each platform object within the store.
*   **`WorldView.tsx`**:
    *   The local `useInterpolatedPosition` hook has been removed.
    *   The component now triggers the `fetchPlatformPath` action if a platform's path data is not present in the store.
*   **`utils.ts`**:
    *   A `calculateInterpolatedPosition` utility function was added to perform the client-side position calculation based on the cached `pathPoints`.

**4. Dependencies**

*   Added `three-stdlib` to provide type definitions for `MapControls`.