### PR TITLE
chore: update repository references to davidbits

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,13 +7,13 @@
 #-----------------------------------------------------------------------
 # Owner for critical repo-wide configuration, community files, and CI/CD workflows.
 # This ensures changes to the contribution process or build system are reviewed.
-/.github/                               @the-user-created
-.clang-format                           @the-user-created
-.gitattributes                          @the-user-created
-.gitignore                              @the-user-created
-.gitmodules                             @the-user-created
-LICENSE                                 @the-user-created
-README.md                               @the-user-created
+/.github/                               @davidbits
+.clang-format                           @davidbits
+.gitattributes                          @davidbits
+.gitignore                              @davidbits
+.gitmodules                             @davidbits
+LICENSE                                 @davidbits
+README.md                               @davidbits
 
 
 #-----------------------------------------------------------------------
@@ -22,13 +22,13 @@ README.md                               @the-user-created
 
 # The core C++ radar simulation engine.
 # Includes all source code, CMake build files, and tests.
-/packages/fers/                         @the-user-created
+/packages/fers/                         @davidbits
 
 # The Tauri/React graphical user interface.
 # Includes the frontend React code and the backend Rust/Tauri code.
-/packages/fers-ui/                      @the-user-created
+/packages/fers-ui/                      @davidbits
 
 # The shared XML schema.
 # Changes here can affect both the core simulator and the UI,
 # so they require careful review.
-/packages/schema/                       @the-user-created
+/packages/schema/                       @davidbits

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,5 +2,5 @@
 blank_issues_enabled: false
 contact_links:
     - name: 💬 Ask a Question or Start a Discussion
-      url: https://github.com/the-user-created/FERS/discussions
+      url: https://github.com/davidbits/FERS/discussions
       about: Please use GitHub Discussions for questions, ideas, and general conversation.

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,7 +18,7 @@ The foundational work on FERS was done as part of a PhD dissertation at the Univ
 
 The project was significantly modernized, refactored, and expanded from 2024 onwards by its current lead maintainer.
 
-- David Young (the-user-created)
+- David Young (davidbits)
 
 ## Project Supervision
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,9 @@ You can contribute in many ways:
 
 ## Reporting Bugs
 
-If you find a bug, please check the [existing issues](https://github.com/the-user-created/FERS/issues) to see if it has
+If you find a bug, please check the [existing issues](https://github.com/davidbits/FERS/issues) to see if it has
 already been reported. If not,
-please [open a new bug report](https://github.com/the-user-created/FERS/issues/new/choose).
+please [open a new bug report](https://github.com/davidbits/FERS/issues/new/choose).
 
 When filing a bug report, please include as many details as possible:
 
@@ -46,8 +46,8 @@ When filing a bug report, please include as many details as possible:
 ## Suggesting Enhancements
 
 If you have an idea for a new feature or an improvement, we'd love to hear about it! Please check
-the [existing issues and feature requests](https://github.com/the-user-created/FERS/issues) first. If your idea is new,
-please [open a new feature request](https://github.com/the-user-created/FERS/issues/new/choose).
+the [existing issues and feature requests](https://github.com/davidbits/FERS/issues) first. If your idea is new,
+please [open a new feature request](https://github.com/davidbits/FERS/issues/new/choose).
 
 Provide a clear description of the proposed enhancement and explain the problem it solves or the value it adds.
 
@@ -56,9 +56,9 @@ Provide a clear description of the proposed enhancement and explain the problem 
 Unsure where to begin contributing to FERS? You can start by looking through `good first issue` and `help wanted`
 issues:
 
-- [Good First Issues](https://github.com/the-user-created/FERS/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) - issues
+- [Good First Issues](https://github.com/davidbits/FERS/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) - issues
   which should only require a few lines of code, and a test or two.
-- [Help Wanted Issues](https://github.com/the-user-created/FERS/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) - issues which
+- [Help Wanted Issues](https://github.com/davidbits/FERS/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) - issues which
   should be a bit more involved than `good first issue` issues.
 
 ## Development Setup
@@ -71,7 +71,7 @@ on.
 The core simulator is written in C++.
 
 1. **Prerequisites**: Ensure you have a C++23 compiler, CMake, `libhdf5`, and `libxml2`.
-2. **Clone the repo**: `git clone --recursive https://github.com/the-user-created/FERS.git`
+2. **Clone the repo**: `git clone --recursive https://github.com/davidbits/FERS.git`
 3. **Build**: Follow the detailed build instructions in the [`packages/fers/README.md`](packages/fers/README.md).
 
 ### User Interface (`fers-ui`) Setup

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 <!-- TODO: Build status should be present for both ui and core -->
 
-[![FERS Core CI](https://github.com/the-user-created/FERS/actions/workflows/CMake.yml/badge.svg)](https://github.com/the-user-created/FERS/actions/workflows/CMake.yml)
-[![Documentation](https://github.com/the-user-created/FERS/actions/workflows/docs.yml/badge.svg)](https://github.com/the-user-created/FERS/actions/workflows/docs.yml)
-[![GitHub issues](https://img.shields.io/github/issues/the-user-created/FERS.svg)](https://github.com/the-user-created/FERS/issues)
-[![License: GPL v2](https://img.shields.io/badge/License-GPLv2-blue.svg)](https://github.com/the-user-created/FERS/blob/master/LICENSE)
+[![FERS Core CI](https://github.com/davidbits/FERS/actions/workflows/CMake.yml/badge.svg)](https://github.com/davidbits/FERS/actions/workflows/CMake.yml)
+[![Documentation](https://github.com/davidbits/FERS/actions/workflows/docs.yml/badge.svg)](https://github.com/davidbits/FERS/actions/workflows/docs.yml)
+[![GitHub issues](https://img.shields.io/github/issues/davidbits/FERS.svg)](https://github.com/davidbits/FERS/issues)
+[![License: GPL v2](https://img.shields.io/badge/License-GPLv2-blue.svg)](https://github.com/davidbits/FERS/blob/master/LICENSE)
 
 ![Tech Stack](https://img.shields.io/badge/Core-C%2B%2B%2023-00599C?logo=cplusplus)
 ![Tech Stack](https://img.shields.io/badge/UI-Tauri%20%7C%20React-20232A?logo=react)
@@ -28,7 +28,7 @@ semi-independent packages.
 - **Advanced Data Export:** Output simulation data in HDF5, CSV, and XML formats for analysis.
 - **Geographic Visualization:** Generate KML files from scenarios for accurate visualization in tools like Google Earth.
 - **Modern Documentation:** A continuously updated and
-  deployed [documentation site](https://the-user-created.github.io/FERS/)
+  deployed [documentation site](https://davidbits.github.io/FERS/)
   with a searchable interface, generated directly from the source code.
 - **Unified Schema:** A central XML schema ensures consistency and serves as the single source of truth for scenarios
   across the simulator and the UI.
@@ -65,7 +65,7 @@ Ensure you have the following tools installed on your system:
 Clone the repository and its submodules from the root of the monorepo.
 
 ```bash
-git clone --recursive https://github.com/the-user-created/FERS.git
+git clone --recursive https://github.com/davidbits/FERS.git
 cd FERS
 ```
 
@@ -138,16 +138,16 @@ installed.
 - Copyright (C) 2008-present FERS contributors (see [AUTHORS.md](AUTHORS.md)).
 
 This program is free software; you can redistribute it and/or modify it under the terms of the
-[GNU General Public License](https://github.com/the-user-created/FERS/blob/master/LICENSE) as published by the Free
+[GNU General Public License](https://github.com/davidbits/FERS/blob/master/LICENSE) as published by the Free
 Software Foundation; version 2 of the License.
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
-the [GNU General Public License](https://github.com/the-user-created/FERS/blob/master/LICENSE) for
+the [GNU General Public License](https://github.com/davidbits/FERS/blob/master/LICENSE) for
 more details.
 
 You should have received a copy of
-the [GNU General Public License](https://github.com/the-user-created/FERS/blob/master/LICENSE) along with this program;
+the [GNU General Public License](https://github.com/davidbits/FERS/blob/master/LICENSE) along with this program;
 if not, write to
 the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,7 @@ If you believe you have found a security vulnerability, please report it private
 vulnerability reporting** feature. This ensures the issue can be investigated and addressed before it becomes public
 knowledge.
 
-**➡️ [Report a vulnerability here](https://github.com/the-user-created/FERS/security/advisories/new)**
+**➡️ [Report a vulnerability here](https://github.com/davidbits/FERS/security/advisories/new)**
 
 You can find detailed instructions on the process in GitHub's
 documentation: "[Privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)".
@@ -51,7 +51,7 @@ user-provided input files.
 ### Out of Scope (Considered a Bug, Not a Security Vulnerability)
 
 - The simulator crashing on a malformed or invalid (but not maliciously crafted) `.fersxml` file. Please report these as
-  regular [bug reports](https://github.com/the-user-created/FERS/issues/new/choose).
+  regular [bug reports](https://github.com/davidbits/FERS/issues/new/choose).
 - The simulator producing scientifically incorrect results. This is a correctness issue and should also be reported as a
   bug.
 

--- a/packages/fers-cli/README.md
+++ b/packages/fers-cli/README.md
@@ -1,6 +1,6 @@
 # FERS-CLI: Command-Line Interface for FERS
 
-[![License: GPL v2](https://img.shields.io/badge/License-GPLv2-blue.svg)](https://github.com/the-user-created/FERS/blob/master/LICENSE)
+[![License: GPL v2](https://img.shields.io/badge/License-GPLv2-blue.svg)](https://github.com/davidbits/FERS/blob/master/LICENSE)
 
 **FERS-CLI** is the command-line interface for the FERS simulation engine. It is a lightweight executable that acts as a
 client to the core `libfers` library.
@@ -19,7 +19,7 @@ terminal and to maintain backward compatibility with the original FERS workflow.
 ## Building
 
 The `fers-cli` executable is built as part of the main C++ build process for the monorepo. Please see the build
-instructions in the [`packages/libfers/README.md`](https://github.com/the-user-created/FERS/blob/master/packages/libfers/README.md) file.
+instructions in the [`packages/libfers/README.md`](https://github.com/davidbits/FERS/blob/master/packages/libfers/README.md) file.
 
 After a successful build, the executable can be found at `build/packages/fers-cli/fers-cli`.
 

--- a/packages/fers-ui/README.md
+++ b/packages/fers-ui/README.md
@@ -3,7 +3,7 @@
 ![Framework](https://img.shields.io/badge/Framework-React-61DAFB?logo=react)
 ![Language](https://img.shields.io/badge/Language-TypeScript-3178C6?logo=typescript)
 ![Desktop App](https://img.shields.io/badge/Tauri-v2-FFC336)
-[![License: GPL v2](https://img.shields.io/badge/License-GPLv2-blue.svg)](https://github.com/the-user-created/FERS/blob/master/LICENSE)
+[![License: GPL v2](https://img.shields.io/badge/License-GPLv2-blue.svg)](https://github.com/davidbits/FERS/blob/master/LICENSE)
 
 **fers-ui** is the official graphical user interface for the **Flexible Extensible Radar Simulator (FERS)**. It provides a professional-grade, visual workbench designed to streamline the entire simulation pipeline—from asset creation and scenario construction to simulation execution and results analysis. By offering an intuitive and powerful toolset, fers-ui dramatically improves the usability and accessibility of the core FERS engine.
 
@@ -51,7 +51,7 @@ The application is architected as a multi-modal "Workbench" to provide a clean, 
 
 ## Getting Started
 
-This application is part of a monorepo that includes the core C++ `libfers` library. To set up the complete development environment, please follow the unified **[Development Setup guide in the root README.md](https://github.com/the-user-created/FERS/blob/master/README.md)**.
+This application is part of a monorepo that includes the core C++ `libfers` library. To set up the complete development environment, please follow the unified **[Development Setup guide in the root README.md](https://github.com/davidbits/FERS/blob/master/README.md)**.
 
 Once the environment is set up, you can run the UI from the **repository root** with:
 `bash

--- a/packages/libfers/README.md
+++ b/packages/libfers/README.md
@@ -1,7 +1,7 @@
 # libfers: The FERS Core Simulation Library
 
-[![Build Status](https://github.com/the-user-created/FERS/actions/workflows/CMake.yml/badge.svg)](https://github.com/the-user-created/FERS/actions/workflows/CMake.yml)
-[![License: GPL v2](https://img.shields.io/badge/License-GPLv2-blue.svg)](https://github.com/the-user-created/FERS/blob/master/LICENSE)
+[![Build Status](https://github.com/davidbits/FERS/actions/workflows/CMake.yml/badge.svg)](https://github.com/davidbits/FERS/actions/workflows/CMake.yml)
+[![License: GPL v2](https://img.shields.io/badge/License-GPLv2-blue.svg)](https://github.com/davidbits/FERS/blob/master/LICENSE)
 
 **libfers** is the core C++ simulation engine for the **Flexible Extensible Radar Simulator (FERS)**. It contains all
 the logic for parsing scenarios, modeling physics, executing simulations, and processing output data.
@@ -104,7 +104,7 @@ sudo ldconfig # On Linux, to update the cache
 
 ## Documentation
 
-The source code documentation is automatically built and deployed to our [GitHub Pages site](https://the-user-created.github.io/FERS/). If you wish to build it locally, you will need **Doxygen** and **Graphviz** installed. They are included in the dependency installation commands above.
+The source code documentation is automatically built and deployed to our [GitHub Pages site](https://davidbits.github.io/FERS/). If you wish to build it locally, you will need **Doxygen** and **Graphviz** installed. They are included in the dependency installation commands above.
 
 1. **Configure with documentation enabled:**
 


### PR DESCRIPTION
This pull request updates all project references from `the-user-created` to `davidbits` across the repository. The changes ensure correct attribution, ownership, and links throughout documentation, configuration, and metadata files. This improves project maintainability and clarifies the current lead maintainer and owner.

Ownership and attribution updates:
* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L10-R16): All ownership entries changed from `@the-user-created` to `@davidbits`, including repo-wide configuration, core packages, UI, and schema. [[1]](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L10-R16) [[2]](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L25-R34)
* [`AUTHORS.md`](diffhunk://#diff-784f358cf224418379ac8bdb1eed7279ca2c499e0fadc292f8ab65dcafe3f7e8L21-R21): Updated lead maintainer attribution from "David Young (the-user-created)" to "David Young (davidbits)".

Repository and documentation links:
* `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, and package README files: All links to issues, discussions, documentation, badges, and license files updated to use the `davidbits` GitHub organization instead of `the-user-created`. [[1]](diffhunk://#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2L5-R5) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L34-R36) [[3]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L49-R50) [[4]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L59-R61) [[5]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L74-R74) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R8) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R31) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R68) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L141-R150) [[10]](diffhunk://#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7L25-R25) [[11]](diffhunk://#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7L54-R54) [[12]](diffhunk://#diff-c35eac0f33c0bad99a8c38c8d4458aeb460e10b7512cce19d1fcf19060149ed2L3-R3) [[13]](diffhunk://#diff-c35eac0f33c0bad99a8c38c8d4458aeb460e10b7512cce19d1fcf19060149ed2L22-R22) [[14]](diffhunk://#diff-e163c4890fa9f375f3c2f46cd27626959f4626a409b75a82272c123006439772L6-R6) [[15]](diffhunk://#diff-e163c4890fa9f375f3c2f46cd27626959f4626a409b75a82272c123006439772L54-R54) [[16]](diffhunk://#diff-4f71a99e21ec767f725f41aa342309330debafb6f2327df8730b13698470616aL3-R4) [[17]](diffhunk://#diff-4f71a99e21ec767f725f41aa342309330debafb6f2327df8730b13698470616aL107-R107)